### PR TITLE
Fix/update aurora postgres version 16.11

### DIFF
--- a/Solution/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
+++ b/Solution/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
@@ -82,7 +82,7 @@ export class AuroraPostgres extends Construct {
 
         // Declaring postgres engine
         let auroraEngine = rds.DatabaseClusterEngine.auroraPostgres({
-            version: rds.AuroraPostgresEngineVersion.VER_15_4,
+            version: rds.AuroraPostgresEngineVersion.VER_16_3,
         });
 
         let auroraParameters: any = {};

--- a/Solution/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
+++ b/Solution/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
@@ -82,7 +82,7 @@ export class AuroraPostgres extends Construct {
 
         // Declaring postgres engine
         let auroraEngine = rds.DatabaseClusterEngine.auroraPostgres({
-            version: rds.AuroraPostgresEngineVersion.VER_16_3,
+            version: rds.AuroraPostgresEngineVersion.VER_16_11,
         });
 
         let auroraParameters: any = {};

--- a/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
+++ b/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
@@ -82,7 +82,7 @@ export class AuroraPostgres extends Construct {
 
         // Declaring postgres engine
         let auroraEngine = rds.DatabaseClusterEngine.auroraPostgres({
-            version: rds.AuroraPostgresEngineVersion.VER_15_4,
+            version: rds.AuroraPostgresEngineVersion.VER_16_3,
         });
 
         let auroraParameters: any = {};

--- a/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
+++ b/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts
@@ -82,7 +82,7 @@ export class AuroraPostgres extends Construct {
 
         // Declaring postgres engine
         let auroraEngine = rds.DatabaseClusterEngine.auroraPostgres({
-            version: rds.AuroraPostgresEngineVersion.VER_16_3,
+            version: rds.AuroraPostgresEngineVersion.VER_16_11,
         });
 
         let auroraParameters: any = {};


### PR DESCRIPTION

   ## Description
   This PR fixes the deployment failure issue by updating the Aurora PostgreSQL engine version from the deprecated 15.4 to 16.11.

   ## Issue
   Fixes #4

   ## Changes
   - Updated `AuroraPostgresEngineVersion.VER_15_4` to `AuroraPostgresEngineVersion.VER_16_11` in:
     - `saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts`
     - `Solution/saas-app-plane/product-review-service/cdk/lib/RdsPostgresConstruct.ts`

   ## Problem
   The deployment was failing with the following error:
   ```
   Cannot find version 15.4 for aurora-postgresql (Service: Rds, Status Code: 400)
   ```

   Version 15.4 is no longer available in AWS RDS. Version 16.11 is the latest stable version in the 16.x series.

   ## Testing
   - CDK synthesis completes without errors
   - Version 16.11 is confirmed available in AWS RDS
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
